### PR TITLE
Use post__in and the $post_ids instead of paged

### DIFF
--- a/includes/export-functions.php
+++ b/includes/export-functions.php
@@ -108,12 +108,32 @@ function export_wp_plus( $args = array() ) {
 		}
 	}
 
+	/**
+	 * Filter WP_Query arguments for which posts to export.
+	 *
+	 * @todo Update since
+	 * @since 4.X
+	 *
+	 * @param array $query_args An array of WP_Query arguments.
+	 * @param array $args An array of export arguments.
+	 */
 	$query_args = apply_filters( 'export_wp_query_args', $query_args, $args );
 
-	$post_query_args = $query_args;
-	$post_query_args['fields'] = 'ids';
+	$query_args['fields'] = 'ids';
 
-	$post_ids = get_posts( $post_query_args );
+	$post_ids = get_posts( $query_args );
+
+	/**
+	 * Filter Post IDs to be exported.
+	 *
+	 * @todo Update since
+	 * @since 4.X
+	 *
+	 * @param array $post_ids An array of Post IDs to export.
+	 * @param array $query_args An array of WP_Query arguments.
+	 * @param array $args An array of export arguments.
+	 */
+	$post_ids = apply_filters( 'export_wp_post_ids', $post_ids, $query_args, $args );
 
 	/*
 	 * Get the requested terms ready, empty unless posts filtered by category
@@ -410,19 +430,28 @@ function export_wp_plus( $args = array() ) {
 	do_action( 'rss2_head' );
 	?>
 
-<?php if ( $post_ids ) {
-	$query_args['posts_per_page'] = 20;
-	$query_args['paged'] = 1;
+<?php
+	if ( $post_ids ) {
+		$posts_per_page = 20;
 
-	$query = new WP_Query( $query_args );
+		$wp_query_args = array(
+			'post_type'      => 'any',
+			'post_status'    => 'any',
+			'posts_per_page' => $posts_per_page,
+			'post__in'       => array_slice( $post_ids, 0, $posts_per_page )
+		);
 
-	// Paginate posts 20 at a time
-	while ( $query->have_posts() ) {
-		// Begin Loop.
+		$query = new WP_Query( $wp_query_args );
+
+		$page = 0;
+
+		// Paginate posts 20 at a time
 		while ( $query->have_posts() ) {
-			$query->the_post();
+			// Begin Loop.
+			while ( $query->have_posts() ) {
+				$query->the_post();
 
-			$is_sticky = is_sticky( $post->ID ) ? 1 : 0;
+				$is_sticky = is_sticky( $post->ID ) ? 1 : 0;
 ?>
 	<item>
 		<title><?php
@@ -535,14 +564,17 @@ function export_wp_plus( $args = array() ) {
 <?php	endforeach; ?>
 	</item>
 <?php
+			}
+
+			// Fetch next set of posts
+			$wp_query_args['post__in'] = array_slice( $post_ids, ( $page * $posts_per_page ), $posts_per_page );
+
+			$query->query( $wp_query_args );
+
+			$page++;
 		}
-
-		// Fetch next page of posts
-		$query_args['paged']++;
-
-		$query->query( $query_args );
 	}
-} ?>
+?>
 </channel>
 </rss>
 <?php

--- a/includes/export-functions.php
+++ b/includes/export-functions.php
@@ -55,11 +55,11 @@ function export_wp_plus( $args = array() ) {
 	);
 
 	if ( 'all' != $args['content'] ) {
-		$args['content'] = (array) $args['content'];
+		$post_types = (array) $args['content'];
 
 		$query_args['post_type'] = array();
 
-		foreach( $args['content'] as $post_type ) {
+		foreach( $post_types as $post_type ) {
 			$post_type_object = get_post_type_object( $post_type );
 
 			if ( $post_type_object && $post_type_object->can_export ) {

--- a/includes/export-functions.php
+++ b/includes/export-functions.php
@@ -154,8 +154,8 @@ function export_wp_plus( $args = array() ) {
 		// Put categories in order with no child going before its parent
 		if( $categories ) {
 			while ( $cat = array_shift( $categories ) ) {
-				if ( $cat->parent == 0 || isset( $cats[$cat->parent] ) ) {
-					$cats[$cat->term_id] = $cat;
+				if ( $cat->parent == 0 || isset( $cats[ $cat->parent ] ) ) {
+					$cats[ $cat->term_id ] = $cat;
 				} else {
 					$categories[] = $cat;
 				}
@@ -165,8 +165,8 @@ function export_wp_plus( $args = array() ) {
 		// Put terms in order with no child going before its parent
 		if( $custom_terms ) {
 			while ( $t = array_shift( $custom_terms ) ) {
-				if ( $t->parent == 0 || isset( $terms[$t->parent] ) ) {
-					$terms[$t->term_id] = $t;
+				if ( $t->parent == 0 || isset( $terms[ $t->parent ] ) ) {
+					$terms[ $t->term_id ] = $t;
 				} else {
 					$custom_terms[] = $t;
 				}
@@ -415,13 +415,13 @@ function export_wp_plus( $args = array() ) {
 <?php wxr_authors_list( $post_ids ); ?>
 
 <?php foreach ( $cats as $c ) : ?>
-	<wp:category><wp:term_id><?php echo $c->term_id ?></wp:term_id><wp:category_nicename><?php echo $c->slug; ?></wp:category_nicename><wp:category_parent><?php echo $c->parent ? $cats[$c->parent]->slug : ''; ?></wp:category_parent><?php wxr_cat_name( $c ); ?><?php wxr_category_description( $c ); ?></wp:category>
+	<wp:category><wp:term_id><?php echo $c->term_id ?></wp:term_id><wp:category_nicename><?php echo $c->slug; ?></wp:category_nicename><wp:category_parent><?php echo $c->parent ? $cats[ $c->parent ]->slug : ''; ?></wp:category_parent><?php wxr_cat_name( $c ); ?><?php wxr_category_description( $c ); ?></wp:category>
 <?php endforeach; ?>
 <?php foreach ( $tags as $t ) : ?>
 	<wp:tag><wp:term_id><?php echo $t->term_id ?></wp:term_id><wp:tag_slug><?php echo $t->slug; ?></wp:tag_slug><?php wxr_tag_name( $t ); ?><?php wxr_tag_description( $t ); ?></wp:tag>
 <?php endforeach; ?>
 <?php foreach ( $terms as $t ) : ?>
-	<wp:term><wp:term_id><?php echo $t->term_id ?></wp:term_id><wp:term_taxonomy><?php echo $t->taxonomy; ?></wp:term_taxonomy><wp:term_slug><?php echo $t->slug; ?></wp:term_slug><wp:term_parent><?php echo $t->parent ? $terms[$t->parent]->slug : ''; ?></wp:term_parent><?php wxr_term_name( $t ); ?><?php wxr_term_description( $t ); ?></wp:term>
+	<wp:term><wp:term_id><?php echo $t->term_id ?></wp:term_id><wp:term_taxonomy><?php echo $t->taxonomy; ?></wp:term_taxonomy><wp:term_slug><?php echo $t->slug; ?></wp:term_slug><wp:term_parent><?php echo $t->parent ? $terms[ $t->parent ]->slug : ''; ?></wp:term_parent><?php wxr_term_name( $t ); ?><?php wxr_term_description( $t ); ?></wp:term>
 <?php endforeach; ?>
 <?php if ( 'all' == $args['content'] ) wxr_nav_menu_terms(); ?>
 


### PR DESCRIPTION
Use post__in and the $post_ids to avoid running what could be SQL-intensive queries for each page of posts (depending on WP_Query args)
